### PR TITLE
Precompute row and column counts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ julia:
   - 0.7
   - 1.0
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 notifications:
   email: false
 git:

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/docs/GRM.md
+++ b/docs/GRM.md
@@ -1,0 +1,24 @@
+# Generating the Genetic Relationship Matrix from a SnpArray
+
+The simplest case is equivalent to forming the `m × m` symmetric matrix `X*X'` where
+`X` matrix is the centered, scaled and imputed major allele counts in each column.
+
+To break this down, for each column the operation corresponds to:
+- Copy the column into a floating-point vector according to, for the additive model,
+
+| UInt8 code | value |
+|:----------:| -----:|
+| 0x00 | 0.0 |
+| 0x01 | missing | 
+| 0x02 | 1.0 |
+| 0x03 | 2.0 |
+
+- Evaluate the mean, `μ`, and the scaling factor, `σ`, for the column skipping missing values.  For the additive model the scaling factor is `σ = √(μ(1 - μ / 2))`
+- Imputation: Replace missing values with `μ`
+- Centering: Subtract the mean `μ` from each value.
+- Scaling: Divide by `σ`
+
+Reversing the order of imputation and centering helps as imputation becomes replacing missing values by zero.
+
+In a column generated in this way there will be at most four distinct values.
+It is more effective to generate the four possible values first, the populate the vector and add its contribution to the `X*X'` product.  These four values are `[-μ, 0, 1 - μ, 2 - μ] ./ σ`.

--- a/src/BEDFiles.jl
+++ b/src/BEDFiles.jl
@@ -1,7 +1,7 @@
 __precompile__()
 
 module BEDFiles
-    using LinearAlgebra, Mmap, OffsetArrays, SparseArrays, Statistics, StatsBase
+    using LinearAlgebra, Mmap, OffsetArrays, SparseArrays, StaticArrays, Statistics, StatsBase
     import Base: IndexStyle, convert, copyto!, eltype, getindex, setindex!, length, size
     import Statistics: mean, std, var
     import StatsBase: counts

--- a/src/BEDFiles.jl
+++ b/src/BEDFiles.jl
@@ -5,7 +5,8 @@ module BEDFiles
     import Base: IndexStyle, convert, copyto!, eltype, getindex, setindex!, length, size
     import Statistics: mean, std, var
     import StatsBase: counts
-    export BEDFile, bedvals, counts, grm, maf, minorallele, mean, missingpos, missingrate, std, var
+    export BEDFile, bedvals, counts, grm, maf, maf!, minorallele, minorallele!, 
+        mean, mean!, missingpos, missingrate, missingrate!, std, var
     
     include("bedfile.jl")
     include("summarystats.jl")

--- a/src/BEDFiles.jl
+++ b/src/BEDFiles.jl
@@ -3,7 +3,7 @@ __precompile__()
 module BEDFiles
     using LinearAlgebra, Mmap, OffsetArrays, SparseArrays, StaticArrays, Statistics, StatsBase
     export BEDFile, bedvals, counts, grm, maf, maf!, minorallele, minorallele!, 
-        mean, mean!, missingpos, missingrate, missingrate!, std, var
+        mean, mean!, missingpos, missingrate, missingrate!, std, var, newgrm
     
     
     include("bedfile.jl")

--- a/src/BEDFiles.jl
+++ b/src/BEDFiles.jl
@@ -8,6 +8,7 @@ module BEDFiles
     export BEDFile, bedvals, counts, grm, maf, minorallele, mean, missingpos, missingrate, std, var
     
     include("bedfile.jl")
+    include("summarystats.jl")
 
 """
     BEDvals

--- a/src/BEDFiles.jl
+++ b/src/BEDFiles.jl
@@ -2,14 +2,13 @@ __precompile__()
 
 module BEDFiles
     using LinearAlgebra, Mmap, OffsetArrays, SparseArrays, StaticArrays, Statistics, StatsBase
-    import Base: IndexStyle, convert, copyto!, eltype, getindex, setindex!, length, size
-    import Statistics: mean, std, var
-    import StatsBase: counts
     export BEDFile, bedvals, counts, grm, maf, maf!, minorallele, minorallele!, 
         mean, mean!, missingpos, missingrate, missingrate!, std, var
     
+    
     include("bedfile.jl")
     include("summarystats.jl")
+    include("grm.jl")
 
 """
     BEDvals

--- a/src/bedfile.jl
+++ b/src/bedfile.jl
@@ -4,7 +4,7 @@
 Raw .bed file as a shared, memory-mapped Matrix{UInt8}.
 - `data`: The compressed data matrix in which up to 4 SNP calls are stored in each `UInt8` element
 - `columncounts`: a `4` by `n` `Int` matrix of column counts for each of the 4 possible calls
--
+- `staticcounts`: the contents of columncounts as an n-dimensional vector of `SVector{4, Int}`
 - `rowcounts`: a `4` by `m` array of row counts for each of the 4 possible calls
 - `m`: the number of rows in the virtual array.
 
@@ -37,11 +37,11 @@ function BEDFile(bednm::AbstractString, m::Integer, args...; kwargs...)
             for s in 0:2:6
                 ccounts[((bb >> s) & 0x03) + 1, j] += 1
             end
-            if !iszero(r)
-                bb = data[offset + d + 1]
-                for s in 0:2:(2*(r-1))
-                    ccounts[((bb >> s) & 0x03) + 1, j] += 1
-                end
+        end
+        if !iszero(r)
+            bb = data[offset + d + 1]
+            for s in 0:2:(2*(r-1))
+                ccounts[((bb >> s) & 0x03) + 1, j] += 1
             end
         end
     end

--- a/src/grm.jl
+++ b/src/grm.jl
@@ -21,7 +21,7 @@ function newgrm(f::BEDFile, tempm::AbstractMatrix{<:AbstractFloat};
     m == k || throw(DimensionMismatch("size(f, 1) ≠ size(tempm, 1)"))
     T = eltype(tempm)
     uvec = Vector{T}(undef, 4)
-    result = Matrix{T}(undef, (m, m))
+    result = zeros(T, (m, m))
     colinds = something(colinds, maffromcounts.(f.sccounts) .≥ mafthreshold)
     sccounts = f.sccounts
     ind = 1
@@ -37,10 +37,7 @@ function newgrm(f::BEDFile, tempm::AbstractMatrix{<:AbstractFloat};
             end
             ind += 1
         end
-        if ind > n && j < l
-            fill!(view(tempm, :, j:l), zero(T))
-        end
-        BLAS.syrk!('L', 'N', one(T), tempm, one(T), result)
+        BLAS.syrk!('L', 'N', one(T), j < l ? view(tempm, :, 1:j) : tempm, one(T), result)
     end
     result ./= 2n
     Symmetric(result, :L)

--- a/src/grm.jl
+++ b/src/grm.jl
@@ -3,25 +3,45 @@
 
 Return an `SVector{4,Float64}` of the unique values in the additive model incidence
 """
-function uvals!(uv::Vector{<:AbstractFloat}, v::SVector{4,Int}; impute::Bool=true, center::Bool=true, scale::Bool=true)
+function uvals!(uv::Vector{<:AbstractFloat}, v::AbstractVector{<:Integer})
     μ = meanfromcounts(v)
     σ = sqrt(μ * (1 - μ / 2))
     uv[1] = -μ / σ
     uv[2] = 0
     uv[3] = (1 - μ) / σ
     uv[4] = (2 - μ) / σ
-    uv
+    return uv
 end
 
-function newgrm(f::BEDFile)
+function newgrm(f::BEDFile, tempm::AbstractMatrix{<:AbstractFloat};
+        colinds::Union{Nothing,AbstractVector{Bool}}=nothing,
+        mafthreshold::Real=0.01)
     m, n = size(f)
-    uvec = Vector{Float64}(undef, 4)
-    tempm = Matrix{Float64}(undef, size(f))
-    @inbounds for (j, v) in enumerate(f.sccounts)
-        uvals!(uvec, v)
-        for i in 1:m
-            tempm[i, j] = uvec[f[i,j] + 1]
+    k, l = size(tempm)
+    m == k || throw(DimensionMismatch("size(f, 1) ≠ size(tempm, 1)"))
+    T = eltype(tempm)
+    uvec = Vector{T}(undef, 4)
+    result = Matrix{T}(undef, (m, m))
+    colinds = something(colinds, maffromcounts.(f.sccounts) .≥ mafthreshold)
+    sccounts = f.sccounts
+    ind = 1
+    while ind ≤ n
+        j = 1
+        while j ≤ l && ind ≤ n
+            if colinds[ind]
+                uvals!(uvec, sccounts[ind])
+                @inbounds for i in 1:m
+                    tempm[i, j] = uvec[f[i,ind] + 1]
+                end
+                j += 1
+            end
+            ind += 1
         end
+        if ind > n && j < l
+            fill!(view(tempm, :, j:l), zero(T))
+        end
+        BLAS.syrk!('L', 'N', one(T), tempm, one(T), result)
     end
-    (tempm * tempm') ./ (2n)
+    result ./= 2n
+    Symmetric(result, :L)
 end

--- a/src/grm.jl
+++ b/src/grm.jl
@@ -1,0 +1,27 @@
+"""
+    uvals(v::SVector{4,Int}; impute::Bool=true, center::Bool=true, scale::Bool=true)
+
+Return an `SVector{4,Float64}` of the unique values in the additive model incidence
+"""
+function uvals!(uv::Vector{<:AbstractFloat}, v::SVector{4,Int}; impute::Bool=true, center::Bool=true, scale::Bool=true)
+    μ = meanfromcounts(v)
+    σ = sqrt(μ * (1 - μ / 2))
+    uv[1] = -μ / σ
+    uv[2] = 0
+    uv[3] = (1 - μ) / σ
+    uv[4] = (2 - μ) / σ
+    uv
+end
+
+function newgrm(f::BEDFile)
+    m, n = size(f)
+    uvec = Vector{Float64}(undef, 4)
+    tempm = Matrix{Float64}(undef, size(f))
+    @inbounds for (j, v) in enumerate(f.sccounts)
+        uvals!(uvec, v)
+        for i in 1:m
+            tempm[i, j] = uvec[f[i,j] + 1]
+        end
+    end
+    (tempm * tempm') ./ (2n)
+end

--- a/src/summarystats.jl
+++ b/src/summarystats.jl
@@ -1,0 +1,165 @@
+StatsBase.counts(f::BEDFile; dims=:) = _counts(f, dims)
+
+function _counts(f::BEDFile, dims::Integer)
+    if isone(dims)
+        cc = f.columncounts
+        if all(iszero, cc)
+            m, n = size(f)
+            @inbounds for j in 1:n
+                for i in 1:m
+                    cc[f[i, j] + 1, j] += 1            
+                end
+            end
+        end
+        return cc
+    elseif dims == 2
+        rc = f.rowcounts
+        if all(iszero, rc)
+            m, n = size(f)
+            @inbounds for j in 1:n
+                for i in 1:m
+                    rc[f[i, j] + 1, i] += 1            
+                end
+            end
+        end
+        return rc
+    else
+        throw(ArgumentError("counts(f::BEDFile, dims=k) only defined for k = 1 or 2"))
+    end
+end
+
+_counts(f::BEDFile, ::Colon) = sum(f.staticcounts, dims=2)
+
+Statistics.mean(f::BEDFile; dims=:) = _mean(f, dims)
+
+meanfromcounts(v::SVector{4,Int}) = (v[3] + 2v[4]) / (v[1] + v[3] + v[4])
+
+function _mean(f::BEDFile,  dims::Integer)
+    if isone(dims)
+        reshape(meanfromcounts.(f.staticcounts), (1, size(f, 2)))
+    elseif dims == 2
+        rc = _counts(f, 2)
+        m = size(f, 1)
+        means = Matrix{Float64}(undef, (m, 1))
+        @inbounds for i in 1:m
+            means[i] = (rc[3, i] + 2*rc[4, i]) / (rc[1, i] + rc[3, i] + rc[4, i])
+        end
+        means
+    else
+        throw(ArgumentError("mean(f::BEDFile, dims=k) only defined for k = 1 or 2"))
+    end
+end
+
+function _mean(f::BEDFile, ::Colon)
+    v = sum(f.staticcounts)
+    (v[3] + 2v[4]) / (v[1] + v[3] + v[4])
+end
+
+function Statistics.mean!(out::AbstractMatrix{<:AbstractFloat}, f::BEDFile)
+    k, l = size(out)
+    m, n = size(f)
+    if k == 1 && l == n
+        map!(meanfromcounts, out, f.staticcounts)
+    elseif k == m && l == 1
+        rc = _counts(f, 2)
+        @inbounds for i in 1:m
+            out[i, 1] = (rc[3, i] + 2rc[4, i]) / (rc[1, i] + rc[3, i] + rc[4, i])
+        end
+        out
+    else
+        throw(ArgumentError("mean!(out, f::BEDFile) requires out to be 1 by n or m by 1"))
+    end
+end
+
+function missingrate!(out::AbstractMatrix{<:AbstractFloat}, f::BEDFile)
+    k, l = size(out)
+    m, n = size(f)
+    if k == 1 && l == n
+        cc = f.columncounts
+        @inbounds for j in 1:n
+            out[j] = cc[2, j] / m
+        end
+    elseif k == m && l == 1
+        rc = _counts(f, 2)
+        @inbounds for i in 1:m
+            out[i] = rc[2, i] / n
+        end
+    else
+        throw(ArgumentError("missingrate(out, f::BEDFile) requires out to be 1 by n or m by 1"))
+    end
+    out
+end
+
+missingrate(f::BEDFile; dims=:) = _missingrate(f, dims)
+
+function _missingrate(f::BEDFile, dims::Integer)
+    if isone(dims)
+        missingrate!(Matrix{Float64}(undef, (1, size(f, 2))), f)
+    elseif dims == 2 
+        missingrate!(Matrix{Float64}(undef, (f.m, 1)), f)
+    else
+        throw(ArgumentError("missingrate(f::BEDFile, dims=k) only defined for k = 1 or 2"))
+    end
+end
+
+_missingrate(f::BEDFile, ::Colon) = sum(v -> v[2], f.staticcounts) / length(f)
+
+Statistics.var(f::BEDFile; corrected::Bool=true, mean=nothing, dims=:) = _var(f, corrected, mean, dims)
+
+function _var(f::BEDFile, corrected::Bool, mean, dims::Integer)
+    m, n = size(f)
+    means = something(mean, Statistics.mean(f, dims=dims))
+    if isone(dims)
+        cc = _counts(f, 1)
+        vars = Matrix{Float64}(undef, (1, n))
+        for j in 1:n
+            mnj = means[j]
+            vars[j] = (abs2(mnj)*cc[1,j] + abs2(1.0 - mnj)*cc[3,j] + abs2(2.0 - mnj)*cc[4,j]) /
+            (cc[1,j] + cc[3,j] + cc[4,j] - (corrected ? 1 : 0))
+        end
+        return vars
+    elseif dims == 2
+        rc = _counts(f, 2)
+        vars = Matrix{Float64}(undef, (m, 1))
+        for i in 1:m
+            mni = means[i]
+            vars[i] = (abs2(mni)*rc[1,i] + abs2(1.0 - mni)*rc[3,i] + abs2(2.0 - mni)*rc[4,i]) /
+            (rc[1,i] + rc[3,i] + rc[4,i] - (corrected ? 1 : 0))
+        end
+        return vars
+    end
+    throw(ArgumentError("var(f::BEDFile, dims=k) only defined for k = 1 or 2"))
+end
+
+function maffromcounts(v::SVector{4, Int})
+    freq = (v[3] + 2v[4]) / 2(v[1] + v[3] + v[4])
+    freq ≤ 0.5 ? freq : 1 - freq
+end
+
+function maf!(out::AbstractVector{T}, f::BEDFile) where T <: AbstractFloat
+    cc = _counts(f, 1)
+    map!(maffromcounts, out, f.staticcounts)
+end
+
+"""
+    maf(f::BEDFile)
+
+Return a vector of minor allele frequencies for the columns of `f`.
+
+By definition the minor allele frequency is between 0 and 0.5
+"""
+maf(f::BEDFile) = maf!(Vector{Float64}(undef, size(f, 2)), f)
+
+minorallelefromcounts(v::SVector{4, Int}) = v[1] > v[4]
+
+function minorallele!(out::AbstractVector{Bool}, f::BEDFile)
+    cc = _counts(f, 1)
+    map!(minorallelefromcounts, out, f.staticcounts)
+end
+
+"""
+    minorallele(f::BEDFile)
+
+Return a `Vector{Bool}` indicating if the minor allele in each column is A2
+"""
+minorallele(f::BEDFile) = minorallele!(Vector{Bool}(undef, size(f, 2)), f)

--- a/src/summarystats.jl
+++ b/src/summarystats.jl
@@ -12,9 +12,9 @@ end
 
 _counts(f::BEDFile, ::Colon) = sum(f.sccounts)
 
-@inline nnonmiss(v::SVector{4,Int}) = v[1] + v[3] + v[4]
+@inline nnonmiss(v::AbstractVector{<:Integer}) = v[1] + v[3] + v[4]
 
-meanfromcounts(v::SVector{4,Int}) = (v[3] + 2v[4]) / nnonmiss(v)
+meanfromcounts(v::AbstractVector{<:Integer}) = (v[3] + 2v[4]) / nnonmiss(v)
 
 Statistics.mean(f::BEDFile; dims=:) = _mean(f, dims)
 
@@ -102,7 +102,7 @@ _missingrate(f::BEDFile, ::Colon) = sum(view(f.rowcounts, 2, :)) / length(f)
 Statistics.var(f::BEDFile; corrected::Bool=true, mean=nothing, dims=:) = 
     _var(f, corrected, mean, dims)
 
-function varfromcounts(v::SVector{4,Int}, corrected::Bool, mn)
+function varfromcounts(v::AbstractVector{<:Integer}, corrected::Bool, mn)
     nnmiss = nnonmiss(v)
     if mn == nothing
         mn = (v[3] + 2v[4]) / nnmiss
@@ -121,7 +121,7 @@ function _var(f::BEDFile, corrected::Bool, mean, dims::Integer)
     end
 end
 
-function maffromcounts(v::SVector{4, Int})
+function maffromcounts(v::AbstractVector{<:Integer})
     freq = (v[3] + 2v[4]) / (2 * nnonmiss(v))
     freq ≤ 0.5 ? freq : 1 - freq
 end
@@ -137,7 +137,7 @@ By definition the minor allele frequency is between 0 and 0.5
 """
 maf(f::BEDFile) = maffromcounts.(f.sccounts)
 
-minorallelefromcounts(v::SVector{4, Int}) = v[1] > v[4]
+minorallelefromcounts(v::AbstractVector{<:Integer}) = v[1] > v[4]
 
 minorallele!(out::AbstractVector{Bool}, f::BEDFile) =
     map!(minorallelefromcounts, out, f.sccounts)

--- a/src/summarystats.jl
+++ b/src/summarystats.jl
@@ -1,18 +1,8 @@
 StatsBase.counts(f::BEDFile; dims=:) = _counts(f, dims)
 
 function _counts(f::BEDFile, dims::Integer)
-    if isone(dims)
-        cc = f.columncounts
-        if all(iszero, cc)
-            m, n = size(f)
-            @inbounds for j in 1:n
-                for i in 1:m
-                    cc[f[i, j] + 1, j] += 1            
-                end
-            end
-        end
-        return cc
-    elseif dims == 2
+    isone(dims) && return f.columncounts
+    if dims == 2
         rc = f.rowcounts
         if all(iszero, rc)
             m, n = size(f)
@@ -28,68 +18,86 @@ function _counts(f::BEDFile, dims::Integer)
     end
 end
 
-_counts(f::BEDFile, ::Colon) = sum(f.staticcounts, dims=2)
+_counts(f::BEDFile, ::Colon) = sum(f.staticcounts)
 
 Statistics.mean(f::BEDFile; dims=:) = _mean(f, dims)
 
-meanfromcounts(v::SVector{4,Int}) = (v[3] + 2v[4]) / (v[1] + v[3] + v[4])
-
 function _mean(f::BEDFile,  dims::Integer)
     if isone(dims)
-        reshape(meanfromcounts.(f.staticcounts), (1, size(f, 2)))
+        mean!(Matrix{Float64}(undef, (1, size(f, 2))), f)
     elseif dims == 2
-        rc = _counts(f, 2)
-        m = size(f, 1)
-        means = Matrix{Float64}(undef, (m, 1))
-        @inbounds for i in 1:m
-            means[i] = (rc[3, i] + 2*rc[4, i]) / (rc[1, i] + rc[3, i] + rc[4, i])
-        end
-        means
+        mean!(Matrix{Float64}(undef, (size(f, 1), 1)), f)
     else
         throw(ArgumentError("mean(f::BEDFile, dims=k) only defined for k = 1 or 2"))
     end
 end
 
-function _mean(f::BEDFile, ::Colon)
-    v = sum(f.staticcounts)
-    (v[3] + 2v[4]) / (v[1] + v[3] + v[4])
-end
+nnonmiss(v::SVector{4,Int}) = v[1] + v[3] + v[4]
+
+meanfromcounts(v::SVector{4,Int}) = (v[3] + 2v[4]) / nnonmiss(v)
+
+_mean(f::BEDFile, ::Colon) = meanfromcounts(sum(f.staticcounts))
 
 function Statistics.mean!(out::AbstractMatrix{<:AbstractFloat}, f::BEDFile)
     k, l = size(out)
     m, n = size(f)
-    if k == 1 && l == n
-        map!(meanfromcounts, out, f.staticcounts)
-    elseif k == m && l == 1
+    errormsg = "size(out) = $(size(out)) should be (1,1) or (1,$n) or ($m,1)"
+    if isone(k)
+        if isone(l)
+            out[1] = _mean(f, :)
+        elseif l == n
+            map!(meanfromcounts, out, f.staticcounts)
+        else
+            throw(ArgumentError(errormsg))
+        end
+    elseif k == m && isone(l)
         rc = _counts(f, 2)
         @inbounds for i in 1:m
             out[i, 1] = (rc[3, i] + 2rc[4, i]) / (rc[1, i] + rc[3, i] + rc[4, i])
         end
-        out
     else
-        throw(ArgumentError("mean!(out, f::BEDFile) requires out to be 1 by n or m by 1"))
+        throw(ArgumentError(errmsg))
     end
+    out
 end
 
+"""
+    missingrate!(out::AbstractMatrix{<:AbstractFloat}, f::BEDFile)
+
+Overwrite the contents of `out` with the missing rates according to the size of `out`.
+
+If `size(out) == (1,size(f,2))` it is overwritten with the column-wise missing rates.
+If `size(out) == (size(f,1),1)` it is overwritten with the row-wise missing rates.
+If `size(out) == (1,1)` it is overwritten with the overall rate of missing values.
+"""
 function missingrate!(out::AbstractMatrix{<:AbstractFloat}, f::BEDFile)
     k, l = size(out)
     m, n = size(f)
-    if k == 1 && l == n
-        cc = f.columncounts
-        @inbounds for j in 1:n
-            out[j] = cc[2, j] / m
+    errormsg = "size(out) = $(size(out)) should be (1,1) or (1,$n) or ($m,1)"
+    if isone(k)
+        if isone(l)
+            out[1] = sum(v -> v[2], f.staticcounts) / length(f)
+        elseif l == n
+            map!(v -> v[2] / m, out, f.staticcounts)
+        else
+            throw(ArgumentError(errormsg))
         end
-    elseif k == m && l == 1
+    elseif k == m && isone(l)
         rc = _counts(f, 2)
         @inbounds for i in 1:m
             out[i] = rc[2, i] / n
         end
     else
-        throw(ArgumentError("missingrate(out, f::BEDFile) requires out to be 1 by n or m by 1"))
+        throw(ArgumentError(errormsg))
     end
     out
 end
 
+"""
+    missingrate(f::BEDFile; dims=:)
+
+Return the rate of missing values in `f` by column (`dims=1`), by row (`dims=2`) or overall (`dims=:`, the default).
+"""
 missingrate(f::BEDFile; dims=:) = _missingrate(f, dims)
 
 function _missingrate(f::BEDFile, dims::Integer)
@@ -104,42 +112,42 @@ end
 
 _missingrate(f::BEDFile, ::Colon) = sum(v -> v[2], f.staticcounts) / length(f)
 
-Statistics.var(f::BEDFile; corrected::Bool=true, mean=nothing, dims=:) = _var(f, corrected, mean, dims)
+Statistics.var(f::BEDFile; corrected::Bool=true, mean=nothing, dims=:) = 
+    _var(f, corrected, mean, dims)
+
+function varfromcounts(v::SVector{4,Int}, corrected::Bool, mn)
+    nnmiss = nnonmiss(v)
+    if mn == nothing
+        mn = (v[3] + 2v[4]) / nnmiss
+    end
+    (abs2(mn)*v[1] + abs2(1 - mn)*v[3] + abs2(2 - mn)*v[4]) / (nnmiss - Int(corrected))
+end    
 
 function _var(f::BEDFile, corrected::Bool, mean, dims::Integer)
     m, n = size(f)
-    means = something(mean, Statistics.mean(f, dims=dims))
     if isone(dims)
-        cc = _counts(f, 1)
-        vars = Matrix{Float64}(undef, (1, n))
-        for j in 1:n
-            mnj = means[j]
-            vars[j] = (abs2(mnj)*cc[1,j] + abs2(1.0 - mnj)*cc[3,j] + abs2(2.0 - mnj)*cc[4,j]) /
-            (cc[1,j] + cc[3,j] + cc[4,j] - (corrected ? 1 : 0))
-        end
-        return vars
+        reshape([varfromcounts(v, corrected, mean) for v in f.staticcounts], (1, size(f,2)))
     elseif dims == 2
+        means = something(mean, Statistics.mean(f, dims=2))
         rc = _counts(f, 2)
         vars = Matrix{Float64}(undef, (m, 1))
         for i in 1:m
             mni = means[i]
             vars[i] = (abs2(mni)*rc[1,i] + abs2(1.0 - mni)*rc[3,i] + abs2(2.0 - mni)*rc[4,i]) /
-            (rc[1,i] + rc[3,i] + rc[4,i] - (corrected ? 1 : 0))
+                (rc[1,i] + rc[3,i] + rc[4,i] - Int(corrected))
         end
-        return vars
+        vars
+    else
+        throw(ArgumentError("var(f::BEDFile, dims=k) only defined for k = 1 or 2"))
     end
-    throw(ArgumentError("var(f::BEDFile, dims=k) only defined for k = 1 or 2"))
 end
 
 function maffromcounts(v::SVector{4, Int})
-    freq = (v[3] + 2v[4]) / 2(v[1] + v[3] + v[4])
+    freq = (v[3] + 2v[4]) / (2 * nnonmiss(v))
     freq ≤ 0.5 ? freq : 1 - freq
 end
 
-function maf!(out::AbstractVector{T}, f::BEDFile) where T <: AbstractFloat
-    cc = _counts(f, 1)
-    map!(maffromcounts, out, f.staticcounts)
-end
+maf!(out::AbstractVector{<:AbstractFloat}, f::BEDFile) = map!(maffromcounts, out, f.staticcounts)
 
 """
     maf(f::BEDFile)
@@ -152,10 +160,8 @@ maf(f::BEDFile) = maf!(Vector{Float64}(undef, size(f, 2)), f)
 
 minorallelefromcounts(v::SVector{4, Int}) = v[1] > v[4]
 
-function minorallele!(out::AbstractVector{Bool}, f::BEDFile)
-    cc = _counts(f, 1)
+minorallele!(out::AbstractVector{Bool}, f::BEDFile) =
     map!(minorallelefromcounts, out, f.staticcounts)
-end
 
 """
     minorallele(f::BEDFile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,53 +14,6 @@ const mouse = BEDFile(BEDFiles.datadir("mouse.bed"))
     @test eltype(mouse) == UInt8
 end
 
-@testset "counts" begin
-    cc = counts(EUR, dims=1)
-    @test counts(EUR) == sum(cc, dims=2)
-    @test size(cc) == (4, size(EUR, 2))
-    @test view(cc, :, 1) == [2, 0, 70, 307]
-    @test all(sum(cc, dims = 1) .== size(EUR, 1))
-    @test all(iszero, view(cc, 2, :))
-    rc = counts(EUR, dims=2)
-    @test size(rc) == (4, size(EUR, 1))
-    @test view(rc, :, 1) == [2997, 0, 13143, 37911]
-    @test all(sum(rc, dims = 1) .== size(EUR, 2))
-    @test all(iszero, view(rc, 2, :))
-    @test_throws ArgumentError counts(EUR, dims=3)
-end
-
-@testset "means" begin
-    cmns = mean(EUR, dims = 1)
-    @test size(cmns) == (1, size(EUR, 2))
-    @test cmns[1] ≈ 1.804749340369393
-    @test mean(cmns) ≈ mean(EUR)
-    @test minimum(cmns) ≈ 1.0
-    @test maximum(cmns) ≈ 1.9788918205804749
-    rmns = mean(EUR, dims = 2)
-    @test size(rmns) == (size(EUR, 1), 1)
-    @test rmns[1] ≈ 1.6459454959205195
-    @test mean(rmns) ≈ mean(EUR)
-    rmnextrma = extrema(rmns)
-    @test rmnextrma[1] ≈ 1.637749532848606
-    @test rmnextrma[2] ≈ 1.6627259440158368
-    @test_throws ArgumentError mean(EUR, dims=3)
-end
-
-@testset "var/std" begin
-    cvars = var(EUR, dims = 1)
-    @test size(cvars) == (1, size(EUR, 2))
-    @test cvars[1] ≈ 0.16812553224162724
-    @test iszero(minimum(cvars))
-    @test maximum(cvars) ≈ 0.8705727966941688
-    @test std(EUR, dims = 1) ≈ sqrt.(cvars)
-    rvars = var(EUR, dims = 2)
-    @test size(rvars) == (size(EUR, 1), 1)
-    @test rvars[1] ≈ 0.33960146078503206
-    @test minimum(rvars) ≈ 0.31972707244268267
-    @test maximum(rvars) ≈ 0.365901927927013
-    @test std(EUR, dims = 2) ≈ sqrt.(rvars)
-end
-
 @testset "missingpos" begin
     mp = missingpos(mouse)
     cc = counts(mouse, dims=1)
@@ -68,3 +21,5 @@ end
     @test sum(mp, dims = 1) == view(cc, 2:2, :)
     @test sum(mp, dims = 2) == view(counts(mouse, dims=2), 2:2, :)'
 end
+
+include("summaries.jl")

--- a/test/summaries.jl
+++ b/test/summaries.jl
@@ -1,0 +1,97 @@
+using BEDFiles, Test
+
+if !@isdefined(EUR) || !isa(EUR, BEDFile)
+    const EUR = BEDFile(BEDFiles.datadir("EUR_subset.bed"))
+end;
+if !@isdefined(mouse) || !isa(mouse, BEDFile)
+    const mouse = BEDFile(BEDFiles.datadir("mouse.bed"))
+end;
+
+@testset "counts" begin
+    cc = counts(EUR, dims=1)
+    @test counts(EUR) == vec(sum(cc, dims=2))
+    @test size(cc) == (4, size(EUR, 2))
+    @test view(cc, :, 1) == [2, 0, 70, 307]
+    @test all(sum(cc, dims = 1) .== size(EUR, 1))
+    @test all(iszero, view(cc, 2, :))
+    rc = counts(EUR, dims=2)
+    @test size(rc) == (4, size(EUR, 1))
+    @test view(rc, :, 1) == [2997, 0, 13143, 37911]
+    @test all(sum(rc, dims = 1) .== size(EUR, 2))
+    @test all(iszero, view(rc, 2, :))
+    @test_throws ArgumentError counts(EUR, dims=3)
+    @test sum(counts(EUR)) == length(EUR)
+end
+
+@testset "means" begin
+    cmns = mean(EUR, dims = 1)
+    @test size(cmns) == (1, size(EUR, 2))
+    @test cmns ≈ mean!(similar(cmns), EUR)
+    @test cmns[1] ≈ 1.804749340369393
+    @test mean(EUR) ≈ 1.6497440680596342
+    @test minimum(cmns) ≈ 1.0
+    @test maximum(cmns) ≈ 1.9788918205804749
+    rmns = mean(EUR, dims = 2)
+    @test size(rmns) == (size(EUR, 1), 1)
+    @test rmns[1] ≈ 1.6459454959205195
+    @test rmns ≈ mean!(Matrix{Float64}(undef, size(rmns)), EUR)
+    @test mean(rmns) ≈ mean(EUR)
+    rmnextrma = extrema(rmns)
+    @test rmnextrma[1] ≈ 1.637749532848606
+    @test rmnextrma[2] ≈ 1.6627259440158368
+    @test_throws ArgumentError mean(EUR, dims=3)
+    @test mean(EUR) ≈ mean!(Matrix{Float64}(undef, (1,1)), EUR)[1]
+end
+
+@testset "missingrate" begin
+    @test iszero(missingrate(EUR))
+    EURmisscols = missingrate(EUR, dims=1)
+    @test size(EURmisscols) == (1, size(EUR, 2))
+    @test all(iszero, EURmisscols)
+    @test all(iszero, missingrate!(similar(EURmisscols), EUR))
+    EURmissrows = missingrate(EUR, dims=2)
+    @test size(EURmissrows) == (size(EUR, 1), 1)
+    @test all(iszero, EURmissrows)
+    @test EURmissrows == missingrate!(similar(EURmissrows), EUR)
+    @test missingrate(mouse) ≈ 0.0017227159616068255
+    @test missingrate!(Matrix{Float64}(undef, (1,1)), mouse)[1] ≈ 0.0017227159616068255
+    mousemcols = missingrate(mouse, dims=1)
+    @test size(mousemcols) == (1, size(mouse, 2))
+    @test mousemcols ≈ missingrate!(similar(mousemcols), mouse)
+    @test iszero(minimum(mousemcols))
+    @test maximum(mousemcols) ≈ 0.09845360824742268
+end
+
+@testset "var/std" begin
+    cvars = var(EUR, dims = 1)
+    @test size(cvars) == (1, size(EUR, 2))
+    @test cvars[1] ≈ 0.16812553224162724
+    @test iszero(minimum(cvars))
+    @test maximum(cvars) ≈ 0.8705727966941688
+    @test std(EUR, dims = 1) ≈ sqrt.(cvars)
+    rvars = var(EUR, dims = 2)
+    @test size(rvars) == (size(EUR, 1), 1)
+    @test rvars[1] ≈ 0.33960146078503206
+    @test minimum(rvars) ≈ 0.31972707244268267
+    @test maximum(rvars) ≈ 0.365901927927013
+    @test std(EUR, dims = 2) ≈ sqrt.(rvars)
+end
+
+@testset "minorallele" begin
+    mall = minorallele(EUR)
+    @test !any(mall)
+    @test !any(minorallele!(similar(mall), EUR))
+    mall = minorallele(mouse)
+    @test !any(mall)
+    @test !any(minorallele!(similar(mall), mouse))
+end
+
+@testset "maf" begin
+    mafv = maf(EUR)
+    @test size(mafv) == (size(EUR, 2),)
+    @test mafv ≈ maf!(similar(mafv), EUR)
+    @test minimum(mafv) ≈ 0.01055408970976257
+    @test maximum(mafv) == 0.5
+    @test mafv[1] ≈ 0.09762532981530347
+    @test mafv[end] ≈ 0.02638522427440637
+end


### PR DESCRIPTION
- At the time that a `.bed` file is memory-mapped, compute the column and row counts
- Provide views of the column and row counts as `Vector{SVector{4,Int}}`
- Modify summary statistics (`mean`, `var`, `maf`, `minorallele`, `missingrate`) to use the cached column or row counts.
- I attempted to create a new version of the `grm` calculation but it didn't go well.  The original from @Hua-Zhou performs better.  Mine is called `newgrm` and not exported.  For some reason it allocates about 10 times as much memory as the earlier version.
- It is not clear that the work on precomputing the row and column counts is worthwhile.  For one thing, they only work properly with files opened read-only.  If an element of the `data` array is modified the cached values will no longer be valid.